### PR TITLE
Feat/wiener em

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # cmake file to compile src/
 # link against included submodules libnyquist
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)

--- a/README.md
+++ b/README.md
@@ -30,23 +30,23 @@ $ python ./scripts/evaluate-demixed-output.py \
     ./umx-py-xl-out \
     'Punkdisco - Oral Hygiene'
 
-vocals          ==> SDR:   7.377  SIR:  16.028  ISR:  15.628  SAR:   8.376
-drums           ==> SDR:   8.086  SIR:  12.205  ISR:  17.904  SAR:   9.055
-bass            ==> SDR:   5.459  SIR:   8.830  ISR:  13.361  SAR:  10.543
-other           ==> SDR:   1.442  SIR:   1.144  ISR:   5.199  SAR:   2.842
+vocals          ==> SDR:   7.695  SIR:  17.312  ISR:  16.426  SAR:   8.322
+drums           ==> SDR:   8.899  SIR:  14.054  ISR:  14.941  SAR:   9.428
+bass            ==> SDR:   8.338  SIR:  14.352  ISR:  14.171  SAR:  10.971
+other           ==> SDR:   2.017  SIR:   6.266  ISR:   6.821  SAR:   2.410
 
 $ python ./scripts/evaluate-demixed-output.py \
     --musdb-root="/MUSDB18-HQ" \
     ./umx-cpp-xl-out \
     'Punkdisco - Oral Hygiene'
 
-vocals          ==> SDR:   7.695  SIR:  17.312  ISR:  16.426  SAR:   8.322
-drums           ==> SDR:   8.899  SIR:  14.054  ISR:  14.941  SAR:   9.428
-bass            ==> SDR:   8.338  SIR:  14.352  ISR:  14.171  SAR:  10.971
-other           ==> SDR:   2.017  SIR:   6.266  ISR:   6.821  SAR:   2.410
+vocals          ==> SDR:   7.750  SIR:  17.510  ISR:  16.195  SAR:   8.321
+drums           ==> SDR:   9.010  SIR:  14.149  ISR:  14.900  SAR:   9.416
+bass            ==> SDR:   8.349  SIR:  14.348  ISR:  14.160  SAR:  10.990
+other           ==> SDR:   1.987  SIR:   6.282  ISR:   6.674  SAR:   2.461
 ```
 
-In runtime, this is actually slower than the PyTorch inference (and probably much slower than a possible Torch C++ inference implementation). For a 4:23 song, PyTorch takes 13s and umx.cpp takes 22s.
+In runtime, this is actually slower than the PyTorch inference (and probably much slower than a possible Torch C++ inference implementation).
 
 ## Motivation
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # umx.cpp
 
+**:boom: :dizzy: 2023-09-10 update: Wiener-EM is now implemented for maximum performance!**
+
 C++17 implementation of [Open-Unmix](https://github.com/sigsep/open-unmix-pytorch) (UMX), a PyTorch neural network for music demixing.
 
 It uses [libnyquist](https://github.com/ddiakopoulos/libnyquist) to load audio files, the [ggml](https://github.com/ggerganov/ggml) file format to serialize the PyTorch weights of `umxhq` and `umxl` to a binary file format, and [Eigen](https://eigen.tuxfamily.org/index.php?title=Main_Page) (+ OpenMP) to implement the inference of Open-Unmix.
@@ -8,9 +10,9 @@ The float32 weights of UMX are quantized to uint16 during the conversion to the 
 
 ## Performance
 
-The demixed output wav files (and their SDR score) of the main program [`umx.cpp`](./umx.cpp) are mostly identical to the PyTorch models (with the post-processing Wiener-EM step disabled):
+The demixed output wav files (and their SDR score) of the main program [`umx.cpp`](./umx.cpp) are mostly identical to the PyTorch models:
 ```
-# first, standard pytorch inference (no wiener-em)
+# first, standard pytorch inference
 $ python ./scripts/umx_pytorch_inference.py \
     --model=umxl \
     --dest-dir=./umx-py-xl-out \
@@ -38,10 +40,10 @@ $ python ./scripts/evaluate-demixed-output.py \
     ./umx-cpp-xl-out \
     'Punkdisco - Oral Hygiene'
 
-vocals          ==> SDR:   7.377  SIR:  16.028  ISR:  15.628  SAR:   8.376
-drums           ==> SDR:   8.086  SIR:  12.205  ISR:  17.904  SAR:   9.055
-bass            ==> SDR:   5.459  SIR:   8.830  ISR:  13.361  SAR:  10.543
-other           ==> SDR:   1.442  SIR:   1.144  ISR:   5.199  SAR:   2.842
+vocals          ==> SDR:   7.695  SIR:  17.312  ISR:  16.426  SAR:   8.322
+drums           ==> SDR:   8.899  SIR:  14.054  ISR:  14.941  SAR:   9.428
+bass            ==> SDR:   8.338  SIR:  14.352  ISR:  14.171  SAR:  10.971
+other           ==> SDR:   2.017  SIR:   6.266  ISR:   6.821  SAR:   2.410
 ```
 
 In runtime, this is actually slower than the PyTorch inference (and probably much slower than a possible Torch C++ inference implementation). For a 4:23 song, PyTorch takes 13s and umx.cpp takes 22s.

--- a/scripts/umx_pytorch_inference.py
+++ b/scripts/umx_pytorch_inference.py
@@ -79,7 +79,6 @@ if __name__ == '__main__':
     out_specs = torch.unsqueeze(out_specs.permute(4, 2, 1, 0, 3), dim=0)
     out_audios = istft(out_specs)[0]
     print(out_audios.shape)
-    input()
 
     # get istft
     for i, target_name in enumerate(model.keys()):

--- a/scripts/umx_pytorch_inference.py
+++ b/scripts/umx_pytorch_inference.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import openunmix
+from openunmix.filtering import wiener
 import torch
 import torchaudio.backend.sox_io_backend
 import torchaudio
@@ -46,24 +47,45 @@ if __name__ == '__main__':
     mag_spec = torch.abs(torch.view_as_complex(spec))
     phase_spec = torch.angle(torch.view_as_complex(spec))
 
+    out_mag_specs = []
+
     # UMX forward inference
     for target_name, target_model in model.items():
         print(f"Inference for target {target_name}")
         out_mag_spec = target_model(mag_spec)
         print(type(out_mag_spec))
         print(out_mag_spec.shape)
+        out_mag_specs.append(torch.unsqueeze(out_mag_spec, dim=-1))
 
-        # Convert back to complex tensor
-        out_spec = out_mag_spec * torch.exp(1j * phase_spec)
+    out_mag_spec_concat = torch.cat(out_mag_specs, dim=-1)
+    print(f"shape, dtype: {out_mag_spec_concat.shape}, {out_mag_spec_concat.dtype}")
 
-        # get istft
-        out_audio = istft(torch.view_as_real(out_spec))
-        print(out_audio.shape)
-        out_audio = torch.squeeze(out_audio, dim=0)
+    # Convert back to complex tensor
+    #out_spec = out_mag_spec * torch.exp(1j * phase_spec)
+    # do wiener filtering
 
+    wiener_mag_inp = out_mag_spec_concat[0, ...].permute(2, 1, 0, 3)
+    wiener_spec_inp = spec[0, ...].permute(2, 1, 0, 3)
+
+    out_specs = wiener(wiener_mag_inp, wiener_spec_inp)
+
+    # out_specs: torch.Size([44, 2049, 2, 2, 4])
+    # nb_frames, nb_bins, nb_channels, 2, targets
+    # 0          1        2            3  4
+    # permute:
+    #           4  2  1  0  3
+
+    # samples, targets, channels, nb_bins, nb_frames, 2
+    out_specs = torch.unsqueeze(out_specs.permute(4, 2, 1, 0, 3), dim=0)
+    out_audios = istft(out_specs)[0]
+    print(out_audios.shape)
+    input()
+
+    # get istft
+    for i, target_name in enumerate(model.keys()):
         # write to file in directory
         if args.dest_dir is not None:
             os.makedirs(args.dest_dir, exist_ok=True)
-            torchaudio.save(os.path.join(args.dest_dir, f'target_{target_digit_map[target_name]}.wav'), out_audio, sample_rate=44100)
+            torchaudio.save(os.path.join(args.dest_dir, f'target_{target_digit_map[target_name]}.wav'), out_audios[i], sample_rate=44100)
 
     print("Goodbye!")

--- a/src/wiener.cpp
+++ b/src/wiener.cpp
@@ -1,0 +1,436 @@
+#include "wiener.hpp"
+#include "dsp.hpp"
+#include <Eigen/Dense>
+#include <algorithm>
+#include <cmath>
+#include <complex>
+#include <iostream>
+#include <unsupported/Eigen/CXX11/Tensor>
+#include <unsupported/Eigen/CXX11/src/Tensor/TensorChipping.h>
+#include <vector>
+#include <array>
+#include <cassert>
+
+static inline float mulAdd(float a, float b, float c) {
+    return a * b + c;
+}
+
+// Function to compute the absolute maximum value from a complex 2D vector
+static float find_max_abs(const Eigen::Tensor3dXcf &data) {
+    float max_val = 0.0;
+    for (int i = 0; i < data.dimension(0); ++i) {
+        for (int j = 0; j < data.dimension(1); ++j) {
+            for (int k = 0; k < data.dimension(2); ++k) {
+                max_val = std::max(max_val, std::abs(data(i, j, k)));
+            }
+        }
+    }
+    return max_val;
+}
+
+// Function to multiply a complex 2D vector by a real number
+static void multiply_by_scalar(std::vector<std::vector<std::complex<float>>> &data, float scalar) {
+    for (auto &row : data) {
+        for (auto &val : row) {
+            val *= scalar;
+        }
+    }
+}
+
+// Utility function to calculate the multiplicative inverse of a complex number (scalar)
+//static std::complex<float> inv(std::complex<float> z) {
+//    float ez = std::norm(z); // Compute the norm (magnitude squared)
+//    return std::conj(z) / ez;
+//}
+static std::complex<float> inv(std::complex<float> z) {
+    const float threshold = 1e-6;
+    float ez = std::norm(z); // Compute the norm (magnitude squared)
+
+    if (std::abs(ez) < threshold) {
+        return std::complex<float>(1.0 / threshold, 0);  // or whatever large value you find appropriate
+    }
+    return std::conj(z) / ez;
+}
+
+static void invertMatrix(umxcpp::Tensor3D& M) {
+    std::cout << "invert!" << std::endl;
+    for (int ch1 = 0; ch1 < M.data.size(); ++ch1) {
+        std::cout << "iter: " << ch1 << std::endl;
+
+        std::cout << "initialize floats" << std::endl;
+
+        std::complex<float> a(M.data[ch1][0][0], M.data[ch1][0][1]);
+        std::complex<float> b(M.data[ch1][0][1], M.data[ch1][0][1]);
+        std::complex<float> c(M.data[ch1][1][0], M.data[ch1][1][0]);
+        std::complex<float> d(M.data[ch1][1][1], M.data[ch1][1][1]);
+
+        std::cout << "compute det" << std::endl;
+
+        // Compute the determinant
+        std::complex<float> det = a * d - b * c;
+        std::complex<float> invDet = inv(det);
+
+        std::cout << "invert 2x2" << std::endl;
+
+        // Invert the 2x2 matrix
+        std::complex<float> tmp00 = invDet * d;
+        std::complex<float> tmp01 = -invDet * b;
+        std::complex<float> tmp10 = -invDet * c;
+        std::complex<float> tmp11 = invDet * a;
+
+        std::cout << "update floats" << std::endl;
+
+        // Update the original tensor
+        M.data[ch1][0][0] = tmp00.real();
+        M.data[ch1][0][1] = tmp00.imag();
+        M.data[ch1][1][0] = tmp10.real();
+        M.data[ch1][1][1] = tmp10.imag();
+        M.data[ch1][0][1] = tmp01.real();
+        M.data[ch1][1][0] = tmp01.imag();  // Fixed this line
+        M.data[ch1][1][1] = tmp11.real();
+        M.data[ch1][1][1] = tmp11.imag();
+
+        std::cout << "yay!" << std::endl;
+    }
+    std::cout << "Successful invert!" << std::endl;
+}
+
+// Compute the empirical covariance for a source.
+static umxcpp::Tensor5D calculateCovariance(
+    const Eigen::Tensor3dXcf &y_j,
+    const int pos,
+    const int t_end
+) {
+    int nb_frames = y_j.dimension(1);
+    int nb_bins = y_j.dimension(2);
+    int nb_channels = 2;
+
+    // Initialize Cj tensor with zeros
+    umxcpp::Tensor5D Cj(nb_frames, nb_bins, nb_channels, nb_channels, 2);
+
+    for (int frame = pos; frame < t_end; ++frame) {
+        for (int bin = 0; bin < nb_bins; ++bin) {
+            for (int ch1 = 0; ch1 < nb_channels; ++ch1) {
+                for (int ch2 = 0; ch2 < nb_channels; ++ch2) {
+                    // Assuming y_j.left[frame][bin] and y_j.right[frame][bin] are std::complex<float>
+                    std::complex<float> y_j_val_left = y_j(0, frame, bin);
+                    std::complex<float> y_j_val_right = y_j(1, frame, bin);
+
+                    std::complex<float> y_j_val = (ch1 == 0) ? y_j_val_left : y_j_val_right;
+                    std::complex<float> y_j_conj_val = std::conj((ch2 == 0) ? y_j_val_left : y_j_val_right);
+
+                    std::complex<float> result = y_j_val * y_j_conj_val;
+
+                    // Update the tensor
+                    // Assuming that the tensor is indexed as [frame-pos][bin][ch1][ch2][re_im]
+                    Cj.data[frame - pos][bin][ch1][ch2][0] += result.real();
+                    Cj.data[frame - pos][bin][ch1][ch2][1] += result.imag();
+                }
+            }
+        }
+    }
+
+    return Cj;
+}
+
+static umxcpp::Tensor4D sumAlongFirstDimension(const umxcpp::Tensor5D& tensor5d) {
+    int nb_frames = tensor5d.data.size();
+    int nb_bins = tensor5d.data[0].size();
+    int nb_channels1 = tensor5d.data[0][0].size();
+    int nb_channels2 = tensor5d.data[0][0][0].size();
+    int nb_reim = tensor5d.data[0][0][0][0].size();
+
+    // Initialize a 4D tensor filled with zeros
+    umxcpp::Tensor4D result(nb_bins, nb_channels1, nb_channels2, nb_reim);
+
+    for (int frame = 0; frame < nb_frames; ++frame) {
+        for (int bin = 0; bin < nb_bins; ++bin) {
+            for (int ch1 = 0; ch1 < nb_channels1; ++ch1) {
+                for (int ch2 = 0; ch2 < nb_channels2; ++ch2) {
+                    for (int reim = 0; reim < nb_reim; ++reim) {
+                        result.data[bin][ch1][ch2][reim] += tensor5d.data[frame][bin][ch1][ch2][reim];
+                    }
+                }
+            }
+        }
+    }
+
+    return result;
+}
+
+// Wiener filter function
+std::array<Eigen::Tensor3dXcf, 4>
+umxcpp::wiener_filter(Eigen::Tensor3dXcf &mix_stft,
+              const std::array<Eigen::Tensor3dXf, 4> &targets_mag_spectrograms)
+{
+    // first just do naive mix-phase
+    std::array<Eigen::Tensor3dXcf, 4> y;
+
+    Eigen::Tensor3dXf mix_phase = mix_stft.unaryExpr(
+        [](const std::complex<float> &c) { return std::arg(c); });
+
+    for (int target = 0; target < 4; ++target) {
+        y[target] = umxcpp::polar_to_complex(targets_mag_spectrograms[target], mix_phase);
+    }
+
+    // we need to refine the estimates. Scales down the estimates for
+    // numerical stability
+    float max_abs = find_max_abs(mix_stft);
+    std::cout << "max abs is 0?: " << (max_abs == 0.0f) << ", " << max_abs << std::endl;
+
+    // Dividing mix_stft by max_abs
+    for (int i = 0; i < mix_stft.dimension(1); ++i) {
+        for (int j = 0; j < mix_stft.dimension(2); ++j) {
+            mix_stft(0, i, j) /= std::complex<float>{max_abs, max_abs};
+            mix_stft(1, i, j) /= std::complex<float>{max_abs, max_abs};
+        }
+    }
+
+    // Dividing y by max_abs
+    for (int source = 0; source < 4; ++source) {
+        for (int i = 0; i < mix_stft.dimension(1); ++i) {
+            for (int j = 0; j < mix_stft.dimension(2); ++j) {
+                y[source](0, i, j) /= std::complex<float>{max_abs, max_abs};
+                y[source](1, i, j) /= std::complex<float>{max_abs, max_abs};
+            }
+        }
+    }
+
+    // call expectation maximization
+    // y = expectation_maximization(y, mix_stft, iterations, eps=eps)[0]
+
+    const int nb_channels = 2;
+    const int nb_frames = mix_stft.dimension(1);
+    const int nb_bins = mix_stft.dimension(2);
+    const int nb_sources = 4;
+    const float eps = WIENER_EPS;
+
+    // Create and initialize the 5D tensor
+    umxcpp::Tensor3D regularization(nb_channels, nb_channels, 2); // The 5D tensor
+    // Fill the diagonal with sqrt(eps) for all 3D slices in dimensions 0 and 1
+    regularization.fill_diagonal(std::sqrt(eps));
+
+    std::vector<Tensor4D> R; // A vector to hold each source's covariance matrix
+    for (int j = 0; j < nb_sources; ++j) {
+        R.emplace_back(Tensor4D(nb_bins, nb_channels, nb_channels, 2));
+    }
+
+    Tensor1D weight(nb_bins);  // A 1D tensor (vector) of zeros
+    Tensor3D v(nb_frames, nb_bins, nb_sources);  // A 3D tensor of zeros
+
+    for (int it = 0; it < WIENER_ITERATIONS; ++it) {
+        for (int frame = 0; frame < nb_frames; ++frame) {
+            for (int bin = 0; bin < nb_bins; ++bin) {
+                for (int source = 0; source < nb_sources; ++source) {
+                    float sumSquare = 0.0f;
+                    for (int channel = 0; channel < nb_channels; ++channel) {
+                        float realPart = 0.0f;
+                        float imagPart = 0.0f;
+
+                        for (int arrayIdx = 0; arrayIdx < 4; ++arrayIdx) { // Looping over the std::array
+                            realPart += y[source](channel, frame, bin).real();
+                            realPart += y[source](channel, frame, bin).imag();
+                        }
+
+                        sumSquare += (realPart * realPart) + (imagPart * imagPart);
+                    }
+                    // Divide by the number of channels to get the average
+                    v.data[frame][bin][source] = sumSquare / nb_channels;
+                }
+            }
+        }
+
+        for (int j = 0; j < nb_sources; ++j) {
+            R[j].setZero();  // Assume Tensor4d has a method to set all its elements to zero
+            weight.fill(WIENER_EPS); // Initialize with small epsilon (assume Tensor1d has a fill method)
+
+            int pos = 0;
+            int batchSize = WIENER_EM_BATCH_SIZE > 0 ? WIENER_EM_BATCH_SIZE : nb_frames;
+            while (pos < nb_frames) {
+                std::cout << "pos 1: " << pos << std::endl;
+                int t_end = std::min(nb_frames, pos + batchSize);
+
+                // Assuming `calculateCovariance` calculates the 5D covariance matrix for the given slice of y
+                umxcpp::Tensor5D tempR = calculateCovariance(y[j], pos, t_end);  // size: (nb_bins, nb_channels, nb_channels, 2)
+
+                // Sum the calculated covariance into R[j]
+                //R[j] += tempR;
+
+                // Sum along the first (time/frame) dimension to get a 4D tensor
+                umxcpp::Tensor4D tempR4D = sumAlongFirstDimension(tempR);
+
+                // Add to existing R[j]
+                // Assuming R[j] and tempR4D have the same dimensions
+                for (int bin = 0; bin < R[j].data.size(); ++bin) {
+                    for (int ch1 = 0; ch1 < R[j].data[0].size(); ++ch1) {
+                        for (int ch2 = 0; ch2 < R[j].data[0][0].size(); ++ch2) {
+                            for (int reim = 0; reim < R[j].data[0][0][0].size(); ++reim) {
+                                R[j].data[bin][ch1][ch2][reim] += tempR4D.data[bin][ch1][ch2][reim];
+                            }
+                        }
+                    }
+                }
+
+                // Update the weight with summed v values across the frames for this batch
+                for (int t = pos; t < t_end; ++t) {
+                    for (int bin = 0; bin < nb_bins; ++bin) {
+                        weight.data[bin] += v.data[t][bin][j];
+                    }
+                }
+
+                pos = t_end;
+            }
+
+            // Normalize R[j] by weight
+            for (int bin = 0; bin < nb_bins; ++bin) {
+                for (int ch1 = 0; ch1 < nb_channels; ++ch1) {
+                    for (int ch2 = 0; ch2 < nb_channels; ++ch2) {
+                        for (int k = 0; k < 2; ++k) {
+                            R[j].data[bin][ch1][ch2][k] /= weight.data[bin];
+                        }
+                    }
+                }
+            }
+
+            // Reset the weight for the next iteration
+            weight.fill(0.0f);
+        }
+
+        std::cout << "where the fuck are we" << std::endl;
+
+        int pos = 0;
+        int batchSize = WIENER_EM_BATCH_SIZE > 0 ? WIENER_EM_BATCH_SIZE : nb_frames;
+        while (pos < nb_frames) {
+            std::cout << "pos 2: " << std::endl;
+
+            int t_end = std::min(nb_frames, pos + batchSize);
+
+            // Reset y values to zero for this batch
+            // Assuming you have a way to set all elements of y between frames pos and t_end to 0.0
+
+            // Compute mix covariance matrix Cxx
+            //Tensor5D Cxx = regularization; // Assuming copy constructor or assignment operator performs deep copy
+            Tensor3D Cxx = regularization;
+
+            for (int j = 0; j < nb_sources; ++j) {
+                for (int t = pos; t < t_end; ++t) {
+                    for (int bin = 0; bin < nb_bins; ++bin) {
+                        float multiplier = v.data[t][bin][j];
+                        // Element-wise addition and multiplication to update Cxx
+                        for (int ch1 = 0; ch1 < nb_channels; ++ch1) {
+                            for (int ch2 = 0; ch2 < nb_channels; ++ch2) {
+                                for (int re_im = 0; re_im < 2; ++re_im) {
+                                    Cxx.data[ch1][ch2][re_im] += multiplier * R[j].data[bin][ch1][ch2][re_im];
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            std::cout << "where the fuck are we 2" << std::endl;
+
+            // Invert Cxx
+            invertMatrix(Cxx);  // Assuming invertMatrix performs element-wise inversion
+            Tensor3D inv_Cxx = Cxx;  // Assuming copy constructor or assignment operator performs deep copy
+
+            std::cout << "where the fuck are we 3" << std::endl;
+
+            // Separate the sources
+            for (int j = 0; j < nb_sources; ++j) {
+                std::cout << "source: " << j << std::endl;
+
+                // Initialize with zeros
+                // create gain with broadcast size of inv_Cxx
+                Tensor5D gain(nb_frames, nb_bins, nb_channels, nb_channels, 2);
+                gain.setZero();
+
+                std::cout << "loop 1" << std::endl;
+                for (int frame = 0; frame < nb_frames; ++frame) {
+                    for (int bin = 0; bin < nb_bins; ++bin) {
+                        for (int ch1 = 0; ch1 < nb_channels; ++ch1) {
+                            for (int ch2 = 0; ch2 < nb_channels; ++ch2) {
+                                for (int re_im = 0; re_im < 2; ++re_im) { // Assuming last dimension has size 2 (real/imaginary)
+                                    for (int ch3 = 0; ch3 < nb_channels; ++ch3) {
+                                        gain.data[frame][bin][ch1][ch2][re_im] = mulAdd(
+                                            R[j].data[bin][ch1][ch3][re_im],
+                                            inv_Cxx.data[ch3][ch2][re_im],   // implicit broadcasting
+                                            gain.data[frame][bin][ch1][ch2][re_im] // explicit broadcasting to have independent gains
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                std::cout << "loop 2" << std::endl;
+                // Element-wise multiplication with v
+                for (int t = pos; t < t_end; ++t) {
+                    std::cout << "t: " << t << std::endl;
+                    for (int frame = 0; frame < nb_frames; ++frame) {
+                        for (int bin = 0; bin < nb_bins; ++bin) {
+                            for (int ch1 = 0; ch1 < nb_channels; ++ch1) {
+                                for (int ch2 = 0; ch2 < nb_channels; ++ch2) {
+                                    for (int re_im = 0; re_im < 2; ++re_im) { // Assuming last dimension has size 2 (real/imaginary)
+                                        float multiplier = v.data[frame][bin][j];
+                                        gain.data[frame][bin][ch1][ch2][re_im] *= multiplier;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                std::cout << "loop 3" << std::endl;
+                for (int frame = pos; frame < t_end; ++frame) {
+                    for (int bin = 0; bin < nb_bins; ++bin) {
+                        for (int i = 0; i < nb_channels; ++i) {
+                            for (int j = 0; j < nb_sources; ++j) {
+                                // Assume x.data and y.data have dimensions [frame][bin][channel][re_im]
+                                // and gain.data has dimensions [frame][bin][ch1][ch2][re_im]
+                                float left_real = mulAdd(
+                                    gain.data[frame][bin][i][i][0],  // assuming we use the same channel i for gain
+                                    mix_stft(0, frame, bin).real(),
+                                    y[j](0, frame, bin).real()
+                                );
+                                float right_real = mulAdd(
+                                    gain.data[frame][bin][i][i][0],  // assuming we use the same channel i for gain
+                                    mix_stft(1, frame, bin).real(),
+                                    y[j](1, frame, bin).real()
+                                );
+                                float left_im = mulAdd(
+                                    gain.data[frame][bin][i][i][1],  // assuming we use the same channel i for gain
+                                    mix_stft(0, frame, bin).imag(),
+                                    y[j](0, frame, bin).imag()
+                                );
+                                float right_im = mulAdd(
+                                    gain.data[frame][bin][i][i][1],  // assuming we use the same channel i for gain
+                                    mix_stft(1, frame, bin).imag(),
+                                    y[j](1, frame, bin).imag()
+                                );
+
+                                y[j](0, frame, bin) = std::complex<float>(left_real, left_im);
+                                y[j](1, frame, bin) = std::complex<float>(right_real, right_im);
+                            }
+                        }
+                    }
+                }
+            }
+
+            pos = t_end;
+        }
+    }
+
+    // scale y by max_abs again
+    for (int source = 0; source < 4; ++source) {
+        for (int i = 0; i < mix_stft.dimension(1); ++i) {
+            for (int j = 0; j < mix_stft.dimension(2); ++j) {
+                y[source](0, i, j) *= std::complex{max_abs, max_abs};
+                y[source](1, i, j) *= std::complex{max_abs, max_abs};
+            }
+        }
+    }
+
+    return y;
+}

--- a/src/wiener.cpp
+++ b/src/wiener.cpp
@@ -10,38 +10,25 @@
 #include <vector>
 #include <array>
 #include <cassert>
+#include <tuple>
 
 static inline float mulAdd(float a, float b, float c) {
     return a * b + c;
 }
 
 // Function to compute the absolute maximum value from a complex 2D vector
-static float find_max_abs(const Eigen::Tensor3dXcf &data) {
-    float max_val = 0.0;
+static float find_max_abs(const Eigen::Tensor3dXcf &data, float scale_factor) {
+    float max_val_im = -1.0f;
     for (int i = 0; i < data.dimension(0); ++i) {
         for (int j = 0; j < data.dimension(1); ++j) {
             for (int k = 0; k < data.dimension(2); ++k) {
-                max_val = std::max(max_val, std::abs(data(i, j, k)));
+                max_val_im = std::max(max_val_im, std::sqrt(std::norm(data(i, j, k))));
             }
         }
     }
-    return max_val;
+    return std::max(1.0f, max_val_im/scale_factor);
 }
 
-// Function to multiply a complex 2D vector by a real number
-static void multiply_by_scalar(std::vector<std::vector<std::complex<float>>> &data, float scalar) {
-    for (auto &row : data) {
-        for (auto &val : row) {
-            val *= scalar;
-        }
-    }
-}
-
-// Utility function to calculate the multiplicative inverse of a complex number (scalar)
-//static std::complex<float> inv(std::complex<float> z) {
-//    float ez = std::norm(z); // Compute the norm (magnitude squared)
-//    return std::conj(z) / ez;
-//}
 static std::complex<float> inv(std::complex<float> z) {
     const float threshold = 1e-6;
     float ez = std::norm(z); // Compute the norm (magnitude squared)
@@ -54,7 +41,7 @@ static std::complex<float> inv(std::complex<float> z) {
 
 static void invertMatrix(umxcpp::Tensor3D& M) {
     std::cout << "invert!" << std::endl;
-    for (int ch1 = 0; ch1 < M.data.size(); ++ch1) {
+    for (std::size_t ch1 = 0; ch1 < M.data.size(); ++ch1) {
         std::cout << "iter: " << ch1 << std::endl;
 
         std::cout << "initialize floats" << std::endl;
@@ -96,42 +83,12 @@ static void invertMatrix(umxcpp::Tensor3D& M) {
 }
 
 // Compute the empirical covariance for a source.
+// forward decl
 static umxcpp::Tensor5D calculateCovariance(
     const Eigen::Tensor3dXcf &y_j,
     const int pos,
     const int t_end
-) {
-    int nb_frames = y_j.dimension(1);
-    int nb_bins = y_j.dimension(2);
-    int nb_channels = 2;
-
-    // Initialize Cj tensor with zeros
-    umxcpp::Tensor5D Cj(nb_frames, nb_bins, nb_channels, nb_channels, 2);
-
-    for (int frame = pos; frame < t_end; ++frame) {
-        for (int bin = 0; bin < nb_bins; ++bin) {
-            for (int ch1 = 0; ch1 < nb_channels; ++ch1) {
-                for (int ch2 = 0; ch2 < nb_channels; ++ch2) {
-                    // Assuming y_j.left[frame][bin] and y_j.right[frame][bin] are std::complex<float>
-                    std::complex<float> y_j_val_left = y_j(0, frame, bin);
-                    std::complex<float> y_j_val_right = y_j(1, frame, bin);
-
-                    std::complex<float> y_j_val = (ch1 == 0) ? y_j_val_left : y_j_val_right;
-                    std::complex<float> y_j_conj_val = std::conj((ch2 == 0) ? y_j_val_left : y_j_val_right);
-
-                    std::complex<float> result = y_j_val * y_j_conj_val;
-
-                    // Update the tensor
-                    // Assuming that the tensor is indexed as [frame-pos][bin][ch1][ch2][re_im]
-                    Cj.data[frame - pos][bin][ch1][ch2][0] += result.real();
-                    Cj.data[frame - pos][bin][ch1][ch2][1] += result.imag();
-                }
-            }
-        }
-    }
-
-    return Cj;
-}
+);
 
 static umxcpp::Tensor4D sumAlongFirstDimension(const umxcpp::Tensor5D& tensor5d) {
     int nb_frames = tensor5d.data.size();
@@ -175,14 +132,17 @@ umxcpp::wiener_filter(Eigen::Tensor3dXcf &mix_stft,
 
     // we need to refine the estimates. Scales down the estimates for
     // numerical stability
-    float max_abs = find_max_abs(mix_stft);
-    std::cout << "max abs is 0?: " << (max_abs == 0.0f) << ", " << max_abs << std::endl;
+    float max_abs = find_max_abs(mix_stft, WIENER_SCALE_FACTOR);
 
     // Dividing mix_stft by max_abs
     for (int i = 0; i < mix_stft.dimension(1); ++i) {
         for (int j = 0; j < mix_stft.dimension(2); ++j) {
-            mix_stft(0, i, j) /= std::complex<float>{max_abs, max_abs};
-            mix_stft(1, i, j) /= std::complex<float>{max_abs, max_abs};
+            mix_stft(0, i, j) = std::complex<float>{
+                    mix_stft(0, i, j).real()/max_abs,
+                    mix_stft(0, i, j).imag()/max_abs};
+            mix_stft(1, i, j) = std::complex<float>{
+                    mix_stft(1, i, j).real()/max_abs,
+                    mix_stft(1, i, j).imag()/max_abs};
         }
     }
 
@@ -190,8 +150,12 @@ umxcpp::wiener_filter(Eigen::Tensor3dXcf &mix_stft,
     for (int source = 0; source < 4; ++source) {
         for (int i = 0; i < mix_stft.dimension(1); ++i) {
             for (int j = 0; j < mix_stft.dimension(2); ++j) {
-                y[source](0, i, j) /= std::complex<float>{max_abs, max_abs};
-                y[source](1, i, j) /= std::complex<float>{max_abs, max_abs};
+                y[source](0, i, j) = std::complex<float>{
+                        y[source](0, i, j).real()/max_abs,
+                        y[source](0, i, j).imag()/max_abs};
+                y[source](1, i, j) = std::complex<float>{
+                        y[source](1, i, j).real()/max_abs,
+                        y[source](1, i, j).imag()/max_abs};
             }
         }
     }
@@ -206,7 +170,7 @@ umxcpp::wiener_filter(Eigen::Tensor3dXcf &mix_stft,
     const float eps = WIENER_EPS;
 
     // Create and initialize the 5D tensor
-    umxcpp::Tensor3D regularization(nb_channels, nb_channels, 2); // The 5D tensor
+    umxcpp::Tensor3D regularization(nb_channels, nb_channels, 2); // The 3D tensor
     // Fill the diagonal with sqrt(eps) for all 3D slices in dimensions 0 and 1
     regularization.fill_diagonal(std::sqrt(eps));
 
@@ -219,6 +183,10 @@ umxcpp::wiener_filter(Eigen::Tensor3dXcf &mix_stft,
     Tensor3D v(nb_frames, nb_bins, nb_sources);  // A 3D tensor of zeros
 
     for (int it = 0; it < WIENER_ITERATIONS; ++it) {
+        std::cout << "wiener iter: " << it << std::endl;
+
+        // update the PSD as the average spectrogram over channels
+        // PSD container is v
         for (int frame = 0; frame < nb_frames; ++frame) {
             for (int bin = 0; bin < nb_bins; ++bin) {
                 for (int source = 0; source < nb_sources; ++source) {
@@ -227,10 +195,8 @@ umxcpp::wiener_filter(Eigen::Tensor3dXcf &mix_stft,
                         float realPart = 0.0f;
                         float imagPart = 0.0f;
 
-                        for (int arrayIdx = 0; arrayIdx < 4; ++arrayIdx) { // Looping over the std::array
-                            realPart += y[source](channel, frame, bin).real();
-                            realPart += y[source](channel, frame, bin).imag();
-                        }
+                        realPart += y[source](channel, frame, bin).real();
+                        imagPart += y[source](channel, frame, bin).imag();
 
                         sumSquare += (realPart * realPart) + (imagPart * imagPart);
                     }
@@ -240,41 +206,38 @@ umxcpp::wiener_filter(Eigen::Tensor3dXcf &mix_stft,
             }
         }
 
-        for (int j = 0; j < nb_sources; ++j) {
-            R[j].setZero();  // Assume Tensor4d has a method to set all its elements to zero
+        std::cout << "begin update spatial covariance matrices R" << std::endl;
+        for (int source = 0; source < nb_sources; ++source) {
+            R[source].setZero();  // Assume Tensor4d has a method to set all its elements to zero
             weight.fill(WIENER_EPS); // Initialize with small epsilon (assume Tensor1d has a fill method)
 
             int pos = 0;
             int batchSize = WIENER_EM_BATCH_SIZE > 0 ? WIENER_EM_BATCH_SIZE : nb_frames;
+
             while (pos < nb_frames) {
-                std::cout << "pos 1: " << pos << std::endl;
                 int t_end = std::min(nb_frames, pos + batchSize);
 
-                // Assuming `calculateCovariance` calculates the 5D covariance matrix for the given slice of y
-                umxcpp::Tensor5D tempR = calculateCovariance(y[j], pos, t_end);  // size: (nb_bins, nb_channels, nb_channels, 2)
+                umxcpp::Tensor5D tempR = calculateCovariance(y[source], pos, t_end);
 
                 // Sum the calculated covariance into R[j]
-                //R[j] += tempR;
-
                 // Sum along the first (time/frame) dimension to get a 4D tensor
                 umxcpp::Tensor4D tempR4D = sumAlongFirstDimension(tempR);
 
-                // Add to existing R[j]
-                // Assuming R[j] and tempR4D have the same dimensions
-                for (int bin = 0; bin < R[j].data.size(); ++bin) {
-                    for (int ch1 = 0; ch1 < R[j].data[0].size(); ++ch1) {
-                        for (int ch2 = 0; ch2 < R[j].data[0][0].size(); ++ch2) {
-                            for (int reim = 0; reim < R[j].data[0][0][0].size(); ++reim) {
-                                R[j].data[bin][ch1][ch2][reim] += tempR4D.data[bin][ch1][ch2][reim];
+                // Add to existing R[j]; (R[j], tempR4D have the same dimensions)
+                for (std::size_t bin = 0; bin < R[source].data.size(); ++bin) {
+                    for (std::size_t ch1 = 0; ch1 < R[source].data[0].size(); ++ch1) {
+                        for (std::size_t ch2 = 0; ch2 < R[source].data[0][0].size(); ++ch2) {
+                            for (std::size_t reim = 0; reim < R[source].data[0][0][0].size(); ++reim) {
+                                R[source].data[bin][ch1][ch2][reim] += tempR4D.data[bin][ch1][ch2][reim];
                             }
                         }
                     }
                 }
 
-                // Update the weight with summed v values across the frames for this batch
+                // Update the weight summed v values across the frames for this batch
                 for (int t = pos; t < t_end; ++t) {
                     for (int bin = 0; bin < nb_bins; ++bin) {
-                        weight.data[bin] += v.data[t][bin][j];
+                        weight.data[bin] += v.data[t][bin][source];
                     }
                 }
 
@@ -286,7 +249,7 @@ umxcpp::wiener_filter(Eigen::Tensor3dXcf &mix_stft,
                 for (int ch1 = 0; ch1 < nb_channels; ++ch1) {
                     for (int ch2 = 0; ch2 < nb_channels; ++ch2) {
                         for (int k = 0; k < 2; ++k) {
-                            R[j].data[bin][ch1][ch2][k] /= weight.data[bin];
+                            R[source].data[bin][ch1][ch2][k] /= weight.data[bin];
                         }
                     }
                 }
@@ -295,38 +258,63 @@ umxcpp::wiener_filter(Eigen::Tensor3dXcf &mix_stft,
             // Reset the weight for the next iteration
             weight.fill(0.0f);
         }
+        std::cout << "end update spatial covariance matrices R" << std::endl;
 
-        std::cout << "where the fuck are we" << std::endl;
+        // so far so good!
+        std::cout << "WIENER GOOD, MATCH SO FAR! regularization, R, v, covariance!" << std::endl;
 
         int pos = 0;
         int batchSize = WIENER_EM_BATCH_SIZE > 0 ? WIENER_EM_BATCH_SIZE : nb_frames;
+        std::cout << "while pos < nb_frames loop 2" << std::endl;
         while (pos < nb_frames) {
-            std::cout << "pos 2: " << std::endl;
-
             int t_end = std::min(nb_frames, pos + batchSize);
 
             // Reset y values to zero for this batch
             // Assuming you have a way to set all elements of y between frames pos and t_end to 0.0
+            for (int source = 0; source < 4; ++source) {
+                for (int i = pos; i < t_end; ++i) {
+                     for (int j = 0; j < nb_bins; ++j) {
+                         y[source](0, i, j) = std::complex<float>{0.0f, 0.0f};
+                         y[source](1, i, j) = std::complex<float>{0.0f, 0.0f};
+                     }
+                }
+            }
 
             // Compute mix covariance matrix Cxx
             //Tensor5D Cxx = regularization; // Assuming copy constructor or assignment operator performs deep copy
             Tensor3D Cxx = regularization;
 
-            for (int j = 0; j < nb_sources; ++j) {
+            for (int source = 0; source < nb_sources; ++source) {
                 for (int t = pos; t < t_end; ++t) {
                     for (int bin = 0; bin < nb_bins; ++bin) {
-                        float multiplier = v.data[t][bin][j];
+                        float multiplier = v.data[t][bin][source];
                         // Element-wise addition and multiplication to update Cxx
                         for (int ch1 = 0; ch1 < nb_channels; ++ch1) {
                             for (int ch2 = 0; ch2 < nb_channels; ++ch2) {
                                 for (int re_im = 0; re_im < 2; ++re_im) {
-                                    Cxx.data[ch1][ch2][re_im] += multiplier * R[j].data[bin][ch1][ch2][re_im];
+                                    Cxx.data[ch1][ch2][re_im] += multiplier * R[source].data[bin][ch1][ch2][re_im];
                                 }
                             }
                         }
                     }
                 }
             }
+
+            float Cxx_min = 1000000000000.0f;
+            float Cxx_max = -1000000000000.0f;
+
+            for (int ch1 = 0; ch1 < nb_channels; ++ch1) {
+                for (int ch2 = 0; ch2 < nb_channels; ++ch2) {
+                    for (int re_im = 0; re_im < 2; ++re_im) {
+                        Cxx_min = std::min(Cxx_min, Cxx.data[ch1][ch2][re_im]);
+                        Cxx_max = std::max(Cxx_max, Cxx.data[ch1][ch2][re_im]);
+                    }
+                }
+            }
+
+            std::cout << "mix covariance matrix Cxx: " << Cxx_min << ", " << Cxx_max << std::endl;
+
+            std::cin.ignore();
 
             std::cout << "where the fuck are we 2" << std::endl;
 
@@ -337,8 +325,8 @@ umxcpp::wiener_filter(Eigen::Tensor3dXcf &mix_stft,
             std::cout << "where the fuck are we 3" << std::endl;
 
             // Separate the sources
-            for (int j = 0; j < nb_sources; ++j) {
-                std::cout << "source: " << j << std::endl;
+            for (int source = 0; source < nb_sources; ++source) {
+                std::cout << "source: " << source << std::endl;
 
                 // Initialize with zeros
                 // create gain with broadcast size of inv_Cxx
@@ -353,7 +341,7 @@ umxcpp::wiener_filter(Eigen::Tensor3dXcf &mix_stft,
                                 for (int re_im = 0; re_im < 2; ++re_im) { // Assuming last dimension has size 2 (real/imaginary)
                                     for (int ch3 = 0; ch3 < nb_channels; ++ch3) {
                                         gain.data[frame][bin][ch1][ch2][re_im] = mulAdd(
-                                            R[j].data[bin][ch1][ch3][re_im],
+                                            R[source].data[bin][ch1][ch3][re_im],
                                             inv_Cxx.data[ch3][ch2][re_im],   // implicit broadcasting
                                             gain.data[frame][bin][ch1][ch2][re_im] // explicit broadcasting to have independent gains
                                         );
@@ -373,7 +361,7 @@ umxcpp::wiener_filter(Eigen::Tensor3dXcf &mix_stft,
                             for (int ch1 = 0; ch1 < nb_channels; ++ch1) {
                                 for (int ch2 = 0; ch2 < nb_channels; ++ch2) {
                                     for (int re_im = 0; re_im < 2; ++re_im) { // Assuming last dimension has size 2 (real/imaginary)
-                                        float multiplier = v.data[frame][bin][j];
+                                        float multiplier = v.data[frame][bin][source];
                                         gain.data[frame][bin][ch1][ch2][re_im] *= multiplier;
                                     }
                                 }
@@ -386,32 +374,32 @@ umxcpp::wiener_filter(Eigen::Tensor3dXcf &mix_stft,
                 for (int frame = pos; frame < t_end; ++frame) {
                     for (int bin = 0; bin < nb_bins; ++bin) {
                         for (int i = 0; i < nb_channels; ++i) {
-                            for (int j = 0; j < nb_sources; ++j) {
+                            for (int source = 0; source < nb_sources; ++source) {
                                 // Assume x.data and y.data have dimensions [frame][bin][channel][re_im]
                                 // and gain.data has dimensions [frame][bin][ch1][ch2][re_im]
                                 float left_real = mulAdd(
                                     gain.data[frame][bin][i][i][0],  // assuming we use the same channel i for gain
                                     mix_stft(0, frame, bin).real(),
-                                    y[j](0, frame, bin).real()
+                                    y[source](0, frame, bin).real()
                                 );
                                 float right_real = mulAdd(
                                     gain.data[frame][bin][i][i][0],  // assuming we use the same channel i for gain
                                     mix_stft(1, frame, bin).real(),
-                                    y[j](1, frame, bin).real()
+                                    y[source](1, frame, bin).real()
                                 );
                                 float left_im = mulAdd(
                                     gain.data[frame][bin][i][i][1],  // assuming we use the same channel i for gain
                                     mix_stft(0, frame, bin).imag(),
-                                    y[j](0, frame, bin).imag()
+                                    y[source](0, frame, bin).imag()
                                 );
                                 float right_im = mulAdd(
                                     gain.data[frame][bin][i][i][1],  // assuming we use the same channel i for gain
                                     mix_stft(1, frame, bin).imag(),
-                                    y[j](1, frame, bin).imag()
+                                    y[source](1, frame, bin).imag()
                                 );
 
-                                y[j](0, frame, bin) = std::complex<float>(left_real, left_im);
-                                y[j](1, frame, bin) = std::complex<float>(right_real, right_im);
+                                y[source](0, frame, bin) = std::complex<float>(left_real, left_im);
+                                y[source](1, frame, bin) = std::complex<float>(right_real, right_im);
                             }
                         }
                     }
@@ -426,11 +414,68 @@ umxcpp::wiener_filter(Eigen::Tensor3dXcf &mix_stft,
     for (int source = 0; source < 4; ++source) {
         for (int i = 0; i < mix_stft.dimension(1); ++i) {
             for (int j = 0; j < mix_stft.dimension(2); ++j) {
-                y[source](0, i, j) *= std::complex{max_abs, max_abs};
-                y[source](1, i, j) *= std::complex{max_abs, max_abs};
+                y[source](0, i, j) = std::complex<float>{
+                    y[source](0, i, j).real()*max_abs,
+                    y[source](0, i, j).imag()*max_abs};
+                y[source](1, i, j) = std::complex<float>{
+                    y[source](1, i, j).real()*max_abs,
+                    y[source](1, i, j).imag()*max_abs};
             }
+        }
+
+        if (source == 0) {
+            std::cout << "y_debug: " << y[0](0, 14, 587).real() << ", " << y[0](0, 14, 587).imag() << std::endl;
+            std::cout << "y_debug: " << y[0](0, 23, 1023).real() << ", " << y[0](0, 23, 1023).imag() << std::endl;
         }
     }
 
     return y;
+}
+
+// Compute the empirical covariance for a source.
+/*
+ *   y_j shape: 2, nb_frames_total, 2049
+ *   pos-t_end = nb_frames (i.e. a chunk of y_j)
+ *
+ *   returns Cj:
+ *       shape: nb_frames, nb_bins, nb_channels, nb_channels, realim
+ */
+static umxcpp::Tensor5D calculateCovariance(
+    const Eigen::Tensor3dXcf &y_j,
+    const int pos,
+    const int t_end
+) {
+    //int nb_frames = y_j.dimension(1);
+    int nb_frames = t_end-pos;
+    int nb_bins = y_j.dimension(2);
+    int nb_channels = 2;
+
+    // Initialize Cj tensor with zeros
+    umxcpp::Tensor5D Cj(nb_frames, nb_bins, nb_channels, nb_channels, 2);
+    Cj.setZero();
+
+    for (int frame = 0; frame < nb_frames; ++frame) {
+        for (int bin = 0; bin < nb_bins; ++bin) {
+            for (int ch1 = 0; ch1 < nb_channels; ++ch1) {
+                for (int ch2 = 0; ch2 < nb_channels; ++ch2) {
+                    // assign real
+                    std::complex<float> a = y_j(ch1, frame+pos, bin);
+                    std::complex<float> b = std::conj(y_j(ch2, frame+pos, bin));
+
+                    float a_real = a.real();
+                    float a_imag = a.imag();
+
+                    float b_real = b.real();
+                    float b_imag = b.imag();
+
+                    // Update the tensor
+                    // _mul_add y_j, conj(y_j) -> y_j = a, conj = b
+                    Cj.data[frame][bin][ch1][ch2][0] += (a_real*b_real - a_imag*b_imag);
+                    Cj.data[frame][bin][ch1][ch2][1] += (a_real*b_imag + a_imag*b_real);
+                }
+            }
+        }
+    }
+
+    return Cj;
 }

--- a/src/wiener.hpp
+++ b/src/wiener.hpp
@@ -1,0 +1,168 @@
+#ifndef WIENER_HPP
+#define WIENER_HPP
+
+#include "tensor.hpp"
+#include "dsp.hpp"
+#include <array>
+#include <string>
+#include <vector>
+#include <complex>
+#include <cmath>
+
+namespace umxcpp {
+const float WIENER_EPS = 1e-10f;
+const float WIENER_SCALE_FACTOR = 10.0f;
+
+// try a smaller batch for memory issues
+const int WIENER_EM_BATCH_SIZE = 200;
+const int WIENER_ITERATIONS = 1;
+
+std::array<Eigen::Tensor3dXcf, 4>
+wiener_filter(Eigen::Tensor3dXcf &mix_spectrogram,
+              const std::array<Eigen::Tensor3dXf, 4> &targets_mag_spectrograms);
+
+struct Tensor5D {
+    std::vector<std::vector<std::vector<std::vector<std::vector<float>>>>> data;
+
+    Tensor5D(int dim1, int dim2, int dim3, int dim4, int dim5) {
+        data.resize(dim1);
+        for (int i = 0; i < dim1; ++i) {
+            data[i].resize(dim2);
+            for (int j = 0; j < dim2; ++j) {
+                data[i][j].resize(dim3);
+                for (int k = 0; k < dim3; ++k) {
+                    data[i][j][k].resize(dim4);
+                    for (int l = 0; l < dim4; ++l) {
+                        data[i][j][k][l].resize(dim5, 0.0f);  // Initializing with 0
+                    }
+                }
+            }
+        }
+    }
+
+    // Method to fill diagonal with 1s for a specific 3D slice
+    void fill_diagonal(int dim1, int dim2, float param = 1.0f) {
+        for (int i = 0; i < data[0][0].size(); ++i) {
+            for (int j = 0; j < data[0][0][0].size(); ++j) {
+                if (i == j) {
+                    data[dim1][dim2][i][j][0] = param;
+                }
+            }
+        }
+    }
+
+    // Method to scale the tensor by a scalar
+    void scale_by(float scalar) {
+        for (int i = 0; i < data.size(); ++i) {
+            for (int j = 0; j < data[0].size(); ++j) {
+                for (int k = 0; k < data[0][0].size(); ++k) {
+                    for (int l = 0; l < data[0][0][0].size(); ++l) {
+                        for (int m = 0; m < data[0][0][0][0].size(); ++m) {
+                            data[i][j][k][l][m] *= scalar;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    void setZero() {
+        for (int i = 0; i < data.size(); ++i) {
+            for (int j = 0; j < data[0].size(); ++j) {
+                for (int k = 0; k < data[0][0].size(); ++k) {
+                    for (int l = 0; l < data[0][0][0].size(); ++l) {
+                        for (int m = 0; m < data[0][0][0][0].size(); ++m) {
+                            data[i][j][k][l][m] = 0.0f;
+                        }
+                    }
+                }
+            }
+        }
+    }
+};
+
+struct Tensor4D {
+    std::vector<std::vector<std::vector<std::vector<float>>>> data;
+
+    Tensor4D(int dim1, int dim2, int dim3, int dim4) {
+        resize(dim1, dim2, dim3, dim4);
+    }
+
+    void resize(int dim1, int dim2, int dim3, int dim4) {
+        data.resize(dim1);
+        for (int i = 0; i < dim1; ++i) {
+            data[i].resize(dim2);
+            for (int j = 0; j < dim2; ++j) {
+                data[i][j].resize(dim3);
+                for (int k = 0; k < dim3; ++k) {
+                    data[i][j][k].resize(dim4, 0.0f);  // Initializing with 0
+                }
+            }
+        }
+    }
+
+    void setZero() {
+        for (int i = 0; i < data.size(); ++i) {
+            for (int j = 0; j < data[0].size(); ++j) {
+                for (int k = 0; k < data[0][0].size(); ++k) {
+                    for (int l = 0; l < data[0][0][0].size(); ++l) {
+                        data[i][j][k][l] = 0.0f;
+                    }
+                }
+            }
+        }
+    }
+};
+
+// Tensor3D
+struct Tensor3D {
+    std::vector<std::vector<std::vector<float>>> data;
+
+    Tensor3D(int dim1, int dim2, int dim3) {
+        resize(dim1, dim2, dim3);
+    }
+
+    void resize(int dim1, int dim2, int dim3) {
+        data.resize(dim1);
+        for (int i = 0; i < dim1; ++i) {
+            data[i].resize(dim2);
+            for (int j = 0; j < dim2; ++j) {
+                data[i][j].resize(dim3, 0.0f);  // Initializing with 0
+            }
+        }
+    }
+
+    // Method to fill diagonal with param
+    void fill_diagonal(float param) {
+        for (int i = 0; i < data[0].size(); ++i) {
+            for (int j = 0; j < data[0][0].size(); ++j) {
+                if (i == j) {
+                    data[i][j][0] = param;
+                }
+            }
+        }
+    }
+
+};
+
+// Tensor1D
+struct Tensor1D {
+    std::vector<float> data;
+
+    Tensor1D(int dim1) {
+        resize(dim1);
+    }
+
+    void resize(int dim1) {
+        data.resize(dim1, 0.0f);  // Initializing with 0
+    }
+
+    void fill(float value) {
+        for (int i = 0; i < data.size(); ++i) {
+            data[i] = value;
+        }
+    }
+};
+} // namespace umxcpp
+
+#endif // WIENER_HPP

--- a/src/wiener.hpp
+++ b/src/wiener.hpp
@@ -42,8 +42,8 @@ struct Tensor5D {
 
     // Method to fill diagonal with 1s for a specific 3D slice
     void fill_diagonal(int dim1, int dim2, float param = 1.0f) {
-        for (int i = 0; i < data[0][0].size(); ++i) {
-            for (int j = 0; j < data[0][0][0].size(); ++j) {
+        for (std::size_t i = 0; i < data[0][0].size(); ++i) {
+            for (std::size_t j = 0; j < data[0][0][0].size(); ++j) {
                 if (i == j) {
                     data[dim1][dim2][i][j][0] = param;
                 }
@@ -53,11 +53,11 @@ struct Tensor5D {
 
     // Method to scale the tensor by a scalar
     void scale_by(float scalar) {
-        for (int i = 0; i < data.size(); ++i) {
-            for (int j = 0; j < data[0].size(); ++j) {
-                for (int k = 0; k < data[0][0].size(); ++k) {
-                    for (int l = 0; l < data[0][0][0].size(); ++l) {
-                        for (int m = 0; m < data[0][0][0][0].size(); ++m) {
+        for (std::size_t i = 0; i < data.size(); ++i) {
+            for (std::size_t j = 0; j < data[0].size(); ++j) {
+                for (std::size_t k = 0; k < data[0][0].size(); ++k) {
+                    for (std::size_t l = 0; l < data[0][0][0].size(); ++l) {
+                        for (std::size_t m = 0; m < data[0][0][0][0].size(); ++m) {
                             data[i][j][k][l][m] *= scalar;
                         }
                     }
@@ -67,11 +67,11 @@ struct Tensor5D {
     }
 
     void setZero() {
-        for (int i = 0; i < data.size(); ++i) {
-            for (int j = 0; j < data[0].size(); ++j) {
-                for (int k = 0; k < data[0][0].size(); ++k) {
-                    for (int l = 0; l < data[0][0][0].size(); ++l) {
-                        for (int m = 0; m < data[0][0][0][0].size(); ++m) {
+        for (std::size_t i = 0; i < data.size(); ++i) {
+            for (std::size_t j = 0; j < data[0].size(); ++j) {
+                for (std::size_t k = 0; k < data[0][0].size(); ++k) {
+                    for (std::size_t l = 0; l < data[0][0][0].size(); ++l) {
+                        for (std::size_t m = 0; m < data[0][0][0][0].size(); ++m) {
                             data[i][j][k][l][m] = 0.0f;
                         }
                     }
@@ -102,10 +102,10 @@ struct Tensor4D {
     }
 
     void setZero() {
-        for (int i = 0; i < data.size(); ++i) {
-            for (int j = 0; j < data[0].size(); ++j) {
-                for (int k = 0; k < data[0][0].size(); ++k) {
-                    for (int l = 0; l < data[0][0][0].size(); ++l) {
+        for (std::size_t i = 0; i < data.size(); ++i) {
+            for (std::size_t j = 0; j < data[0].size(); ++j) {
+                for (std::size_t k = 0; k < data[0][0].size(); ++k) {
+                    for (std::size_t l = 0; l < data[0][0][0].size(); ++l) {
                         data[i][j][k][l] = 0.0f;
                     }
                 }
@@ -134,8 +134,8 @@ struct Tensor3D {
 
     // Method to fill diagonal with param
     void fill_diagonal(float param) {
-        for (int i = 0; i < data[0].size(); ++i) {
-            for (int j = 0; j < data[0][0].size(); ++j) {
+        for (std::size_t i = 0; i < data[0].size(); ++i) {
+            for (std::size_t j = 0; j < data[0][0].size(); ++j) {
                 if (i == j) {
                     data[i][j][0] = param;
                 }
@@ -158,7 +158,7 @@ struct Tensor1D {
     }
 
     void fill(float value) {
-        for (int i = 0; i < data.size(); ++i) {
+        for (std::size_t i = 0; i < data.size(); ++i) {
             data[i] = value;
         }
     }


### PR DESCRIPTION
This adds a lot of demixing performance and SDR to umxl. All models of openunmix use Wiener-EM - not implementing it was because of the difficulty of representing the different dimension tensors and broadcast operations used in the open-unmix filtering.py file with Eigen (I find the Tensor API to be tricky):
https://github.com/sigsep/open-unmix-pytorch/blob/4318fb278e1863f4cf8556b513987faf14a15832/openunmix/filtering.py#L338 

I eventually got the job done by implementing my own home-spun Tensor classes with the C++ stdlib for Wiener-EM and writing out every computation in explicit nested for loops.

Addresses #1 